### PR TITLE
Workaround invalid matdata file published by maven

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -37,7 +37,9 @@ jobs:
           PRIVATE_KEY: ${{ secrets.GPG_SECRET_KEY }}
 
       - name: Publish to repository
-        run: ./mvnw deploy -s settings.xml -Dversion.suffix=
+        run: |
+          sed -i "s/-SNAPSHOT//g" pom.xml
+          ./mvnw deploy -s settings.xml
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>javax.visrec</groupId>
     <artifactId>visrec-api</artifactId>
-    <version>1.0.0${version.suffix}</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>javax.visrec:visrec-api</name>
@@ -43,7 +43,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <version.suffix>-SNAPSHOT</version.suffix>
     </properties>
 
     <dependencies>
@@ -75,7 +74,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>


### PR DESCRIPTION
Using variable in &lt;version> field in pom.xml causing gradle not able to resolve dependency properly.

maven publish also gives warning:
https://github.com/JavaVisRec/visrec-api/runs/600140996?check_suite_focus=true#step:6:13

1. increase version to 1.0.1
2. use constant in version
3. use sed to remove -SNAPSHOT in Actions yml file
4. only requires sign at deploy stage